### PR TITLE
Implement LED control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ OBJS = $(addprefix build/, \
 	u8x8_d_ssd1306_128x64_noname.o \
 	stm8s_tim4.o \
 	led1642.o \
+	rgb.o \
+	stm8s_tim2.o \
 )
 
 VPATH = src:vendor/stsw/src:vendor/u8x8

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ OBJS = $(addprefix build/, \
 	u8x8_display.o \
 	u8x8_8x8.o \
 	u8x8_d_ssd1306_128x64_noname.o \
+	stm8s_tim4.o \
+	led1642.o \
 )
 
 VPATH = src:vendor/stsw/src:vendor/u8x8
@@ -38,6 +40,7 @@ all: $(BUILD_DIR)/rgctl.hex $(BUILD_DIR)/rgctl.elf
 
 $(BUILD_DIR)/rgctl.elf: $(BUILD_DIR)/rgctl.sm8
 	cvdwarf  -o $@ $<
+	size $@
 
 $(BUILD_DIR)/rgctl.hex: $(BUILD_DIR)/rgctl.sm8
 	chex -fi -o $@ $<

--- a/src/led1642.c
+++ b/src/led1642.c
@@ -1,0 +1,124 @@
+#include "led1642.h"
+
+enum {
+    LE = GPIO_PIN_6,
+    SCLK = GPIO_PIN_5,
+    SDO = GPIO_PIN_4,
+    BRIGHTNESS_LATCH = 4,
+    BRIGHTNESS_GLOBAL_LATCH = 6,
+    BRIGHTNESS_REG_COUNT = 16
+};
+
+static volatile bool finished_tx = FALSE;
+static volatile bool rising = TRUE;
+static struct Message *message;
+
+_inline static void clock_on(void) {
+    GPIO_WriteHigh(GPIOD, SCLK);
+    GPIO_WriteHigh(GPIOC, SCLK);
+}
+
+_inline static void clock_off(void) {
+    GPIO_WriteLow(GPIOD, SCLK);
+    GPIO_WriteLow(GPIOC, SCLK);
+}
+
+_inline static void sdo_on(void) {
+    GPIO_WriteHigh(GPIOD, SDO);
+    GPIO_WriteHigh(GPIOC, SDO);
+}
+
+_inline static void sdo_off(void) {
+    GPIO_WriteLow(GPIOD, SDO);
+    GPIO_WriteLow(GPIOC, SDO);
+}
+
+_inline static void le_on(void) {
+    GPIO_WriteHigh(GPIOD, LE);
+    GPIO_WriteHigh(GPIOC, LE);
+}
+
+_inline static void le_off(void) {
+    GPIO_WriteLow(GPIOD, LE);
+    GPIO_WriteLow(GPIOC, LE);
+}
+
+void led1642_init(struct Message *msg) {
+    message = msg;
+
+    /**
+     * TIM3 CH1
+     * Generates PWCLK signal for LED1642, 500kHz
+     */
+    GPIO_Init(GPIOD, GPIO_PIN_2, GPIO_MODE_OUT_PP_LOW_SLOW);
+    TIM3_TimeBaseInit(TIM3_PRESCALER_1, 32);
+    TIM3_OC1Init(
+            TIM3_OCMODE_PWM1,
+            TIM3_OUTPUTSTATE_ENABLE,
+            16,
+            TIM3_OCPOLARITY_HIGH
+    );
+    TIM3_Cmd(ENABLE);
+
+    /**
+     * TIM4
+     * Generates the CLK signal for communicating.
+     * Interrupt runs at 200 kHz, CLK therefore runs at 100kHz.
+     * Only active during transmission.
+     */
+    TIM4_DeInit();
+    TIM4_TimeBaseInit(TIM4_PRESCALER_1, 80);
+    TIM4_ITConfig(TIM4_IT_UPDATE, ENABLE);
+
+    GPIO_Init(GPIOD, SDO, GPIO_MODE_OUT_PP_LOW_SLOW);
+    GPIO_Init(GPIOD, SCLK, GPIO_MODE_OUT_PP_LOW_SLOW);
+    GPIO_Init(GPIOD, LE, GPIO_MODE_OUT_PP_LOW_SLOW);
+
+    GPIO_Init(GPIOC, GPIO_PIN_4, GPIO_MODE_OUT_PP_LOW_SLOW);
+    GPIO_Init(GPIOC, GPIO_PIN_5, GPIO_MODE_OUT_PP_LOW_SLOW);
+    GPIO_Init(GPIOC, GPIO_PIN_6, GPIO_MODE_OUT_PP_LOW_SLOW);
+}
+
+void led1642_transmit(void) {
+    finished_tx = FALSE;
+    TIM4_Cmd(ENABLE);
+    while (!finished_tx);
+}
+
+void led1642_set_brightness(const uint32_t brightness) {
+    int idx;
+    message->data = brightness;
+    for (idx = 0; idx < BRIGHTNESS_REG_COUNT - 1; idx++) {
+        message->size = L1642_TWO_BYTES;
+        message->latch = BRIGHTNESS_LATCH;
+        led1642_transmit();
+    }
+    message->size = L1642_TWO_BYTES;
+    // Last brightness value must be sent with a different latch, see datasheet
+    message->latch = BRIGHTNESS_GLOBAL_LATCH;
+    led1642_transmit();
+}
+
+isr void led1642_isr(void) {
+    if (message->size >= 0) {
+        if (rising) {
+            if ((message->data >> message->size) & 0x01) { sdo_on(); }
+            if (message->latch > message->size) { le_on(); }
+            message->size--;
+            clock_on();
+        } else {
+            sdo_off();
+            clock_off();
+        }
+        rising = !rising;
+    } else {
+        sdo_off();
+        le_off();
+        clock_off();
+        TIM4_Cmd(DISABLE);
+        finished_tx = TRUE;
+        rising = TRUE;
+    }
+
+    TIM4_ClearITPendingBit(TIM4_IT_UPDATE);
+}

--- a/src/led1642.h
+++ b/src/led1642.h
@@ -1,0 +1,25 @@
+#ifndef RGCTL_LED1642_H
+#define RGCTL_LED1642_H
+
+#include <stm8s.h>
+#include "rgctl.h"
+
+#define L1642_WR_SW_LATCH 2
+#define L1642_WR_CR_LATCH 7
+
+#define L1642_TWO_BYTES 15
+#define L1642_ALL_ONES 0xFFFF
+
+struct Message {
+    uint16_t data;
+    int8_t size;
+    uint16_t latch;
+};
+
+void led1642_init(struct Message *message);
+void led1642_transmit(void);
+void led1642_set_brightness(uint32_t brightness);
+void led1642_isr(void);
+
+
+#endif //RGCTL_LED1642_H

--- a/src/rgb.c
+++ b/src/rgb.c
@@ -1,0 +1,110 @@
+#include "rgb.h"
+
+enum {
+    RED_GPIO = GPIO_PIN_1,
+    GREEN_GPIO = GPIO_PIN_2,
+    BLUE_GPIO = GPIO_PIN_3
+};
+
+enum STATE {
+        RED,
+        GREEN,
+        BLUE
+};
+
+volatile static enum STATE state = RED;
+volatile static uint8_t red, red_lim, green, green_lim, blue, blue_lim;
+
+_inline void rgb_red_on(void) {
+    GPIO_WriteHigh(GPIOB, GREEN_GPIO);
+    GPIO_WriteHigh(GPIOB, BLUE_GPIO);
+
+    GPIO_WriteLow(GPIOB, RED_GPIO);
+}
+
+_inline void rgb_green_on(void) {
+    GPIO_WriteHigh(GPIOB, RED_GPIO);
+    GPIO_WriteHigh(GPIOB, BLUE_GPIO);
+
+    GPIO_WriteLow(GPIOB, GREEN_GPIO);
+}
+
+_inline void rgb_blue_on(void) {
+    GPIO_WriteHigh(GPIOB, RED_GPIO);
+    GPIO_WriteHigh(GPIOB, GREEN_GPIO);
+
+    GPIO_WriteLow(GPIOB, BLUE_GPIO);
+}
+
+isr void rgb_isr(void) {
+    switch (state) {
+        case RED:
+            red++;
+            if (red >= red_lim) {
+                red = 0;
+                state = GREEN;
+                if (green_lim != 0) {
+                    rgb_green_on();
+                }
+            }
+            break;
+        case GREEN:
+            green++;
+            if (green >= green_lim) {
+                green = 0;
+                state = BLUE;
+                if (blue_lim != 0) {
+                    rgb_blue_on();
+                }
+            }
+            break;
+        case BLUE:
+            blue++;
+            if (blue >= blue_lim) {
+                blue = 0;
+                state = RED;
+                if (red_lim != 0) {
+                    rgb_red_on();
+                }
+            }
+            break;
+    }
+
+    TIM2_ClearITPendingBit(TIM2_IT_UPDATE);
+}
+
+void rgb_init(uint8_t r, uint8_t g, uint8_t b) {
+    red = green = blue = 0;
+    red_lim = r;
+    green_lim = g;
+    blue_lim = b;
+
+    GPIO_Init(GPIOB, RED_GPIO, GPIO_MODE_OUT_PP_HIGH_SLOW);
+    GPIO_Init(GPIOB, GREEN_GPIO, GPIO_MODE_OUT_PP_HIGH_SLOW);
+    GPIO_Init(GPIOB, BLUE_GPIO, GPIO_MODE_OUT_PP_HIGH_SLOW);
+
+    TIM2_TimeBaseInit(TIM2_PRESCALER_1, 160);
+    TIM2_ITConfig(TIM2_IT_UPDATE, ENABLE);
+}
+
+void rgb_start(void) {
+    red = green = blue = 0;
+    state = RED;
+    if (red_lim != 0) {
+        rgb_red_on();
+    }
+
+    TIM2_Cmd(ENABLE);
+}
+
+void rgb_red(uint8_t val) {
+    red_lim = val;
+}
+
+void rgb_green(uint8_t val) {
+    green_lim = val;
+}
+
+void rgb_blue(uint8_t val) {
+    blue_lim = val;
+}

--- a/src/rgb.h
+++ b/src/rgb.h
@@ -1,0 +1,18 @@
+/**
+ * Provides routines to control the red_lim, green_lim and blue_lim tones of LEDs. Since the three different LEDs
+ * must be turned on separately each color is given a timeslot. The ratio of said timeslots determines
+ * the color perceived by the human eye.
+*/
+
+#include <stm8s.h>
+#include "rgctl.h"
+
+isr void rgb_isr(void);
+
+void rgb_init(uint8_t red, uint8_t green, uint8_t blue);
+void rgb_start(void);
+void rgb_stop(void);
+
+void rgb_red(uint8_t val);
+void rgb_green(uint8_t val);
+void rgb_blue(uint8_t val);

--- a/src/rgctl.c
+++ b/src/rgctl.c
@@ -9,7 +9,6 @@ const uint8_t CPU_CLK_MHZ = 16;
 const uint32_t I2C_SPEED = 100000;
 const uint8_t  I2C_SLAVE_ADDRESS_7 = 0x78;
 
-volatile uint16_t sysTick = 0;
 volatile uint8_t i2c_current = 0;
 volatile uint8_t i2c_bytes_left = 0;
 volatile uint8_t *i2c_bytes = NULL;
@@ -24,11 +23,6 @@ _inline void delay_cycles(uint16_t cycles) {
 
 _inline void delay_us(uint16_t micro) {
     delay_cycles(us_cycles(micro));
-}
-
-isr void sysTickHandler() {
-    sysTick++;
-    TIM1_ClearITPendingBit(TIM1_IT_UPDATE);
 }
 
 uint8_t i2c_hw_byte_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr) {
@@ -76,26 +70,6 @@ void setupHardware(void) {
     CLK_HSIPrescalerConfig(CLK_PRESCALER_HSIDIV1);
 
     led1642_init(&message);
-
-    /**
-     * TIM1 CH3
-     * Used for debugging purposes. Should output a 1kHz signal representing the system tick
-     */
-    GPIO_Init(GPIOC, GPIO_PIN_3, GPIO_MODE_OUT_PP_LOW_SLOW);
-    TIM1_TimeBaseInit(16, TIM1_COUNTERMODE_UP, 1000, 0);
-    TIM1_OC3Init(
-        TIM1_OCMODE_PWM1,
-        TIM1_OUTPUTSTATE_ENABLE,
-        TIM1_OUTPUTNSTATE_DISABLE,
-        500,
-        TIM1_OCPOLARITY_HIGH,
-        TIM1_OCNPOLARITY_LOW,
-        TIM1_OCIDLESTATE_RESET,
-        TIM1_OCNIDLESTATE_RESET
-    );
-    TIM1_ITConfig(TIM1_IT_UPDATE, ENABLE);
-    TIM1_CtrlPWMOutputs(ENABLE);
-    TIM1_Cmd(ENABLE);
 
     /**
      * I2C Setup for SSD1306 OLED screen

--- a/src/rgctl.c
+++ b/src/rgctl.c
@@ -2,7 +2,7 @@
 #include <u8x8.h>
 #include "rgctl.h"
 #include "led1642.h"
-
+#include "rgb.h"
 
 const uint8_t CPU_CLK_MHZ = 16;
 
@@ -70,6 +70,7 @@ void setupHardware(void) {
     CLK_HSIPrescalerConfig(CLK_PRESCALER_HSIDIV1);
 
     led1642_init(&message);
+    rgb_init(80, 0, 30);
 
     /**
      * I2C Setup for SSD1306 OLED screen
@@ -111,6 +112,7 @@ int main(void) {
     led1642_transmit();
 
     led1642_set_brightness(1024);
+    rgb_start();
 
 	while(1) {}
 }

--- a/src/vector.c
+++ b/src/vector.c
@@ -3,6 +3,7 @@
 
 extern void _stext();
 extern void led1642_isr();
+extern void rgb_isr();
 
 void trapHandler() {
     GPIO_WriteHigh(GPIOC, GPIO_PIN_7);
@@ -28,7 +29,7 @@ void (* const @vector vector_table[32])() = {
     NULL,			// SPI EOF
     NULL,	        // TIMER 1 OVF
     NULL,			// TIMER 1 CAP
-    NULL,	        // TIMER 2 OVF
+    rgb_isr,	    // TIMER 2 OVF
     NULL,			// TIMER 2 CAP
     NULL,			// TIMER 3 OVF
     NULL,			// TIMER 3 CAP

--- a/src/vector.c
+++ b/src/vector.c
@@ -2,7 +2,6 @@
 #include "rgctl.h"
 
 extern void _stext();
-extern void sysTickHandler();
 extern void led1642_isr();
 
 void trapHandler() {
@@ -27,7 +26,7 @@ void (* const @vector vector_table[32])() = {
     NULL,			// RESERVED
     NULL,			// RESERVED
     NULL,			// SPI EOF
-    sysTickHandler,	// TIMER 1 OVF
+    NULL,	        // TIMER 1 OVF
     NULL,			// TIMER 1 CAP
     NULL,	        // TIMER 2 OVF
     NULL,			// TIMER 2 CAP

--- a/src/vector.c
+++ b/src/vector.c
@@ -3,9 +3,10 @@
 
 extern void _stext();
 extern void sysTickHandler();
+extern void led1642_isr();
 
 void trapHandler() {
-    GPIO_WriteHigh(GPIOC, GPIO_PIN_5);
+    GPIO_WriteHigh(GPIOC, GPIO_PIN_7);
     while (1);
 }
 
@@ -28,7 +29,7 @@ void (* const @vector vector_table[32])() = {
     NULL,			// SPI EOF
     sysTickHandler,	// TIMER 1 OVF
     NULL,			// TIMER 1 CAP
-    NULL,			// TIMER 2 OVF
+    NULL,	        // TIMER 2 OVF
     NULL,			// TIMER 2 CAP
     NULL,			// TIMER 3 OVF
     NULL,			// TIMER 3 CAP
@@ -38,7 +39,7 @@ void (* const @vector vector_table[32])() = {
     NULL,			// UART TX
     NULL,			// UART RX
     NULL,			// ADC
-    NULL,			// TIMER 4 OVF
+    led1642_isr,	// TIMER 4 OVF
     NULL,			// EEPROM ECC
     NULL,			// Reserved
     NULL,			// Reserved


### PR DESCRIPTION
This PR provides support for controlling the onboard LEDs. The color and brightness are fixed in the program, further development and integration with the onboard rotary encoder should make this interactive.

Existing code like the SysTIck timer has been removed or disabled (I2C) since they blocked development and right now RGB control and rotary encoder integration is the priority.