### PR TITLE
style: implement clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+Language: Cpp
+BasedOnStyle: Google
+AlignAfterOpenBracket: BlockIndent
+AlignConsecutiveBitFields: Consecutive
+AllowShortBlocksOnASingleLine: Always
+AllowShortLoopsOnASingleLine: true
+ColumnLimit: 100
+IndentWidth: 4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,7 @@ repos:
           - --fix=lf
       - id: end-of-file-fixer
       - id: check-yaml
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v16.0.6
+    hooks:
+      - id: clang-format

--- a/src/led1642.c
+++ b/src/led1642.c
@@ -13,29 +13,17 @@ static volatile bool finished_tx = FALSE;
 static volatile bool rising = TRUE;
 static struct Message *message;
 
-_inline static void clock_on(void) {
-    GPIO_WriteHigh(GPIOD, SCLK);
-}
+_inline static void clock_on(void) { GPIO_WriteHigh(GPIOD, SCLK); }
 
-_inline static void clock_off(void) {
-    GPIO_WriteLow(GPIOD, SCLK);
-}
+_inline static void clock_off(void) { GPIO_WriteLow(GPIOD, SCLK); }
 
-_inline static void sdo_on(void) {
-    GPIO_WriteHigh(GPIOD, SDO);
-}
+_inline static void sdo_on(void) { GPIO_WriteHigh(GPIOD, SDO); }
 
-_inline static void sdo_off(void) {
-    GPIO_WriteLow(GPIOD, SDO);
-}
+_inline static void sdo_off(void) { GPIO_WriteLow(GPIOD, SDO); }
 
-_inline static void le_on(void) {
-    GPIO_WriteHigh(GPIOD, LE);
-}
+_inline static void le_on(void) { GPIO_WriteHigh(GPIOD, LE); }
 
-_inline static void le_off(void) {
-    GPIO_WriteLow(GPIOD, LE);
-}
+_inline static void le_off(void) { GPIO_WriteLow(GPIOD, LE); }
 
 void led1642_init(struct Message *msg) {
     message = msg;
@@ -46,12 +34,7 @@ void led1642_init(struct Message *msg) {
      */
     GPIO_Init(GPIOD, GPIO_PIN_2, GPIO_MODE_OUT_PP_LOW_SLOW);
     TIM3_TimeBaseInit(TIM3_PRESCALER_1, 32);
-    TIM3_OC1Init(
-            TIM3_OCMODE_PWM1,
-            TIM3_OUTPUTSTATE_ENABLE,
-            16,
-            TIM3_OCPOLARITY_HIGH
-    );
+    TIM3_OC1Init(TIM3_OCMODE_PWM1, TIM3_OUTPUTSTATE_ENABLE, 16, TIM3_OCPOLARITY_HIGH);
     TIM3_Cmd(ENABLE);
 
     /**
@@ -72,7 +55,8 @@ void led1642_init(struct Message *msg) {
 void led1642_transmit(void) {
     finished_tx = FALSE;
     TIM4_Cmd(ENABLE);
-    while (!finished_tx);
+    while (!finished_tx)
+        ;
 }
 
 void led1642_set_brightness(const uint32_t brightness) {

--- a/src/led1642.h
+++ b/src/led1642.h
@@ -2,6 +2,7 @@
 #define RGCTL_LED1642_H
 
 #include <stm8s.h>
+
 #include "rgctl.h"
 
 #define L1642_WR_SW_LATCH 2
@@ -21,5 +22,4 @@ void led1642_transmit(void);
 void led1642_set_brightness(uint32_t brightness);
 void led1642_isr(void);
 
-
-#endif //RGCTL_LED1642_H
+#endif  // RGCTL_LED1642_H

--- a/src/rgb.c
+++ b/src/rgb.c
@@ -1,16 +1,8 @@
 #include "rgb.h"
 
-enum {
-    RED_GPIO = GPIO_PIN_1,
-    GREEN_GPIO = GPIO_PIN_2,
-    BLUE_GPIO = GPIO_PIN_3
-};
+enum { RED_GPIO = GPIO_PIN_1, GREEN_GPIO = GPIO_PIN_2, BLUE_GPIO = GPIO_PIN_3 };
 
-enum STATE {
-        RED,
-        GREEN,
-        BLUE
-};
+enum STATE { RED, GREEN, BLUE };
 
 volatile static enum STATE state = RED;
 volatile static uint8_t red, red_lim, green, green_lim, blue, blue_lim;
@@ -43,9 +35,7 @@ isr void rgb_isr(void) {
             if (red >= red_lim) {
                 red = 0;
                 state = GREEN;
-                if (green_lim != 0) {
-                    rgb_green_on();
-                }
+                if (green_lim != 0) { rgb_green_on(); }
             }
             break;
         case GREEN:
@@ -53,9 +43,7 @@ isr void rgb_isr(void) {
             if (green >= green_lim) {
                 green = 0;
                 state = BLUE;
-                if (blue_lim != 0) {
-                    rgb_blue_on();
-                }
+                if (blue_lim != 0) { rgb_blue_on(); }
             }
             break;
         case BLUE:
@@ -63,9 +51,7 @@ isr void rgb_isr(void) {
             if (blue >= blue_lim) {
                 blue = 0;
                 state = RED;
-                if (red_lim != 0) {
-                    rgb_red_on();
-                }
+                if (red_lim != 0) { rgb_red_on(); }
             }
             break;
     }
@@ -90,21 +76,13 @@ void rgb_init(uint8_t r, uint8_t g, uint8_t b) {
 void rgb_start(void) {
     red = green = blue = 0;
     state = RED;
-    if (red_lim != 0) {
-        rgb_red_on();
-    }
+    if (red_lim != 0) { rgb_red_on(); }
 
     TIM2_Cmd(ENABLE);
 }
 
-void rgb_red(uint8_t val) {
-    red_lim = val;
-}
+void rgb_red(uint8_t val) { red_lim = val; }
 
-void rgb_green(uint8_t val) {
-    green_lim = val;
-}
+void rgb_green(uint8_t val) { green_lim = val; }
 
-void rgb_blue(uint8_t val) {
-    blue_lim = val;
-}
+void rgb_blue(uint8_t val) { blue_lim = val; }

--- a/src/rgb.h
+++ b/src/rgb.h
@@ -1,10 +1,11 @@
 /**
- * Provides routines to control the red_lim, green_lim and blue_lim tones of LEDs. Since the three different LEDs
- * must be turned on separately each color is given a timeslot. The ratio of said timeslots determines
- * the color perceived by the human eye.
-*/
+ * Provides routines to control the red_lim, green_lim and blue_lim tones of LEDs. Since the three
+ * different LEDs must be turned on separately each color is given a timeslot. The ratio of said
+ * timeslots determines the color perceived by the human eye.
+ */
 
 #include <stm8s.h>
+
 #include "rgctl.h"
 
 isr void rgb_isr(void);

--- a/src/rgctl.c
+++ b/src/rgctl.c
@@ -1,13 +1,15 @@
+#include "rgctl.h"
+
 #include <stm8s.h>
 #include <u8x8.h>
-#include "rgctl.h"
+
 #include "led1642.h"
 #include "rgb.h"
 
 const uint8_t CPU_CLK_MHZ = 16;
 
 const uint32_t I2C_SPEED = 100000;
-const uint8_t  I2C_SLAVE_ADDRESS_7 = 0x78;
+const uint8_t I2C_SLAVE_ADDRESS_7 = 0x78;
 
 volatile uint8_t i2c_current = 0;
 volatile uint8_t i2c_bytes_left = 0;
@@ -17,36 +19,36 @@ u8x8_t display;
 
 struct Message message = {0};
 
-_inline void delay_cycles(uint16_t cycles) {
-    _asm("nop\n $N:\n decw X\n jrne $L\n nop\n", cycles);
-}
+_inline void delay_cycles(uint16_t cycles) { _asm("nop\n $N:\n decw X\n jrne $L\n nop\n", cycles); }
 
-_inline void delay_us(uint16_t micro) {
-    delay_cycles(us_cycles(micro));
-}
+_inline void delay_us(uint16_t micro) { delay_cycles(us_cycles(micro)); }
 
 uint8_t i2c_hw_byte_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr) {
-    switch(msg) {
+    switch (msg) {
         case U8X8_MSG_BYTE_SEND:
             i2c_current = 0;
             i2c_bytes_left = arg_int;
             i2c_bytes = arg_ptr;
             while (i2c_current < i2c_bytes_left) {
                 I2C->DR = i2c_bytes[i2c_current++];
-                while (!(I2C->SR1 & I2C_SR1_TXE));
+                while (!(I2C->SR1 & I2C_SR1_TXE))
+                    ;
             }
             break;
         case U8X8_MSG_BYTE_START_TRANSFER:
             I2C->CR2 |= I2C_CR2_START;
-            while (!(I2C->SR1 & I2C_SR1_SB));
+            while (!(I2C->SR1 & I2C_SR1_SB))
+                ;
 
             I2C->DR = I2C_SLAVE_ADDRESS_7;
-            while (!(I2C->SR1 & I2C_SR1_ADDR));
+            while (!(I2C->SR1 & I2C_SR1_ADDR))
+                ;
             (void)I2C->SR3;
             break;
         case U8X8_MSG_BYTE_END_TRANSFER:
             I2C->CR2 |= I2C_CR2_STOP;
-            while (I2C->SR3 & I2C_SR3_MSL);
+            while (I2C->SR3 & I2C_SR3_MSL)
+                ;
             break;
         case U8X8_MSG_BYTE_INIT:
         case U8X8_MSG_BYTE_SET_DC:
@@ -59,9 +61,7 @@ uint8_t i2c_hw_byte_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr
 }
 
 uint8_t gpio_delay_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr) {
-    if (msg == U8X8_MSG_DELAY_MILLI) {
-        delay_us(arg_int * 1000);
-    }
+    if (msg == U8X8_MSG_DELAY_MILLI) { delay_us(arg_int * 1000); }
 
     return 1;
 }
@@ -91,13 +91,12 @@ int main(void) {
     setupHardware();
     _asm("rim");
 
-//    u8x8_Setup(&display, u8x8_d_ssd1306_128x64_noname, u8x8_cad_ssd13xx_i2c, i2c_hw_byte_cb, gpio_delay_cb);
-//    u8x8_InitDisplay(&display);
-//    u8x8_SetPowerSave(&display, 0);
-//    u8x8_ClearDisplay(&display);
-//
-//    u8x8_SetFont(&display, u8x8_font_courB18_2x3_r);
-//    u8x8_DrawString(&display, 1, 10, "Coracao");
+    //    u8x8_Setup(&display, u8x8_d_ssd1306_128x64_noname, u8x8_cad_ssd13xx_i2c, i2c_hw_byte_cb,
+    //    gpio_delay_cb); u8x8_InitDisplay(&display); u8x8_SetPowerSave(&display, 0);
+    //    u8x8_ClearDisplay(&display);
+    //
+    //    u8x8_SetFont(&display, u8x8_font_courB18_2x3_r);
+    //    u8x8_DrawString(&display, 1, 10, "Coracao");
 
     // Set CFG-15=1, enables 12 bit PWM counter
     message.data = 1 << L1642_TWO_BYTES;
@@ -114,5 +113,5 @@ int main(void) {
     led1642_set_brightness(1024);
     rgb_start();
 
-	while(1) {}
+    while (1) {}
 }

--- a/src/rgctl.h
+++ b/src/rgctl.h
@@ -1,13 +1,17 @@
 #ifndef RGCTL_RGCTL_H
 #define RGCTL_RGCTL_H
 
+#include <stm8s.h>
+
 #define FCLK 16000000
 
 /**
- * For some reason Cosmic decided to use @ for some of its keywords, it also decided to use custom keywords where
- * standard ones already existed (inline). This breaks code insights on places where they are used. Macro magic
- * is used to replace these and only expand them to the value the compiler expects during compilation.
+ * For some reason Cosmic decided to use @ for some of its keywords, it also decided to use custom
+ * keywords where standard ones already existed (inline). This breaks code insights on places where
+ * they are used. Macro magic is used to replace these and only expand them to the value the
+ * compiler expects during compilation.
  */
+// clang-format off
 #ifndef TYPING
 #define isr
 #define _inline inline
@@ -15,9 +19,10 @@
 #define isr @interrupt
 #define _inline @inline
 #endif
+// clang-format on
 
 #define us_cycles(x) ((uint16_t)(((x * (FCLK / 1000000UL)) - 3) / 3))
 _inline void delay_cycles(uint16_t cycles);
 _inline void delay_us(uint16_t micro);
 
-#endif //RGCTL_RGCTL_H
+#endif  // RGCTL_RGCTL_H

--- a/src/stm8s_conf.h
+++ b/src/stm8s_conf.h
@@ -1,29 +1,29 @@
 /**
-  ******************************************************************************
-  * @file    stm8s_conf.h
-  * @author  MCD Application Team
-  * @version V2.3.0
-  * @date    16-June-2017
-  * @brief   This file is used to configure the Library.
-   ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; COPYRIGHT 2014 STMicroelectronics</center></h2>
-  *
-  * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
-  * You may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at:
-  *
-  *        http://www.st.com/software_license_agreement_liberty_v2
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  *
-  ******************************************************************************
-  */
+ ******************************************************************************
+ * @file    stm8s_conf.h
+ * @author  MCD Application Team
+ * @version V2.3.0
+ * @date    16-June-2017
+ * @brief   This file is used to configure the Library.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT 2014 STMicroelectronics</center></h2>
+ *
+ * Licensed under MCD-ST Liberty SW License Agreement V2, (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *        http://www.st.com/software_license_agreement_liberty_v2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef __STM8S_CONF_H
@@ -33,17 +33,17 @@
 #include "stm8s.h"
 
 /* Uncomment the line below to enable peripheral header file inclusion */
-#if defined(STM8S105) || defined(STM8S005) || defined(STM8S103) || defined(STM8S003) ||\
-    defined(STM8S001) || defined(STM8S903) || defined (STM8AF626x) || defined (STM8AF622x)
+#if defined(STM8S105) || defined(STM8S005) || defined(STM8S103) || defined(STM8S003) || \
+    defined(STM8S001) || defined(STM8S903) || defined(STM8AF626x) || defined(STM8AF622x)
 #include "stm8s_adc1.h"
 #endif /* (STM8S105) ||(STM8S103) || (STM8S001) || (STM8S903) || (STM8AF626x) || (STM8AF622x) */
-#if defined(STM8S208) || defined(STM8S207) || defined(STM8S007) || defined (STM8AF52Ax) ||\
-    defined (STM8AF62Ax)
+#if defined(STM8S208) || defined(STM8S207) || defined(STM8S007) || defined(STM8AF52Ax) || \
+    defined(STM8AF62Ax)
 #include "stm8s_adc2.h"
 #endif /* (STM8S208) || (STM8S207) || (STM8AF62Ax) || (STM8AF52Ax) */
 #include "stm8s_awu.h"
 #include "stm8s_beep.h"
-#if defined (STM8S208) || defined (STM8AF52Ax)
+#if defined(STM8S208) || defined(STM8AF52Ax)
 #include "stm8s_can.h"
 #endif /* (STM8S208) || (STM8AF52Ax) */
 #include "stm8s_clk.h"
@@ -59,8 +59,8 @@
 #if !defined(STM8S903) || !defined(STM8AF622x)
 #include "stm8s_tim2.h"
 #endif /* (STM8S903) || (STM8AF622x) */
-#if defined(STM8S208) || defined(STM8S207) || defined(STM8S007) ||defined(STM8S105) ||\
-    defined(STM8S005) ||  defined (STM8AF52Ax) || defined (STM8AF62Ax) || defined (STM8AF626x)
+#if defined(STM8S208) || defined(STM8S207) || defined(STM8S007) || defined(STM8S105) || \
+    defined(STM8S005) || defined(STM8AF52Ax) || defined(STM8AF62Ax) || defined(STM8AF626x)
 #include "stm8s_tim3.h"
 #endif /* (STM8S208) ||defined(STM8S207) || defined(STM8S007) ||defined(STM8S105) */
 #if !defined(STM8S903) || !defined(STM8AF622x)
@@ -69,16 +69,18 @@
 #if defined(STM8S903) || defined(STM8AF622x)
 #include "stm8s_tim5.h"
 #include "stm8s_tim6.h"
-#endif  /* (STM8S903) || (STM8AF622x) */
-#if defined(STM8S208) ||defined(STM8S207) || defined(STM8S007) ||defined(STM8S103) ||\
-    defined(STM8S003) ||defined(STM8S001) || defined(STM8S903) || defined (STM8AF52Ax) || defined (STM8AF62Ax)
+#endif /* (STM8S903) || (STM8AF622x) */
+#if defined(STM8S208) || defined(STM8S207) || defined(STM8S007) || defined(STM8S103) ||   \
+    defined(STM8S003) || defined(STM8S001) || defined(STM8S903) || defined(STM8AF52Ax) || \
+    defined(STM8AF62Ax)
 #include "stm8s_uart1.h"
-#endif /* (STM8S208) || (STM8S207) || (STM8S103) || (STM8S001) || (STM8S903) || (STM8AF52Ax) || (STM8AF62Ax) */
-#if defined(STM8S105) || defined(STM8S005) ||  defined (STM8AF626x)
+#endif /* (STM8S208) || (STM8S207) || (STM8S103) || (STM8S001) || (STM8S903) || (STM8AF52Ax) || \
+          (STM8AF62Ax) */
+#if defined(STM8S105) || defined(STM8S005) || defined(STM8AF626x)
 #include "stm8s_uart2.h"
 #endif /* (STM8S105) || (STM8AF626x) */
-#if defined(STM8S208) ||defined(STM8S207) || defined(STM8S007) || defined (STM8AF52Ax) ||\
-    defined (STM8AF62Ax)
+#if defined(STM8S208) || defined(STM8S207) || defined(STM8S007) || defined(STM8AF52Ax) || \
+    defined(STM8AF62Ax)
 #include "stm8s_uart3.h"
 #endif /* STM8S208 || STM8S207 || STM8AF52Ax || STM8AF62Ax */
 #if defined(STM8AF622x)
@@ -86,10 +88,9 @@
 #endif /* (STM8AF622x) */
 #include "stm8s_wwdg.h"
 
-#define USE_FULL_ASSERT    0
+#define USE_FULL_ASSERT 0
 #define assert_param(expr) ((void)0)
 
 #endif /* __STM8S_CONF_H */
-
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/src/vector.c
+++ b/src/vector.c
@@ -1,4 +1,5 @@
 #include <stm8s.h>
+
 #include "rgctl.h"
 
 extern void _stext();
@@ -7,43 +8,44 @@ extern void rgb_isr();
 
 void trapHandler() {
     GPIO_WriteHigh(GPIOC, GPIO_PIN_7);
-    while (1);
+    while (1)
+        ;
 }
 
 #define NULL 0
-#pragma section const {vector}
+#pragma section const {vector }
 
-void (* const @vector vector_table[32])() = {
-    _stext,			// RESET
-    trapHandler,	// TRAP
-    NULL,			// TLI
-    NULL,			// AWU
-    NULL,			// CLK
-    NULL,			// EXTI PORTA
-    NULL,			// EXTI PORTB
-    NULL,			// EXTI PORTC
-    NULL,			// EXTI PORTD
-    NULL,			// EXTI PORTE
-    NULL,			// RESERVED
-    NULL,			// RESERVED
-    NULL,			// SPI EOF
-    NULL,	        // TIMER 1 OVF
-    NULL,			// TIMER 1 CAP
-    rgb_isr,	    // TIMER 2 OVF
-    NULL,			// TIMER 2 CAP
-    NULL,			// TIMER 3 OVF
-    NULL,			// TIMER 3 CAP
-    NULL,			// RESERVED
-    NULL,			// RESERVED
-    NULL,		    // I2C
-    NULL,			// UART TX
-    NULL,			// UART RX
-    NULL,			// ADC
-    led1642_isr,	// TIMER 4 OVF
-    NULL,			// EEPROM ECC
-    NULL,			// Reserved
-    NULL,			// Reserved
-    NULL,			// Reserved
-    NULL,			// Reserved
-    NULL,			// Reserved
+void (*const @vector vector_table[32])() = {
+    _stext,       // RESET
+    trapHandler,  // TRAP
+    NULL,         // TLI
+    NULL,         // AWU
+    NULL,         // CLK
+    NULL,         // EXTI PORTA
+    NULL,         // EXTI PORTB
+    NULL,         // EXTI PORTC
+    NULL,         // EXTI PORTD
+    NULL,         // EXTI PORTE
+    NULL,         // RESERVED
+    NULL,         // RESERVED
+    NULL,         // SPI EOF
+    NULL,         // TIMER 1 OVF
+    NULL,         // TIMER 1 CAP
+    rgb_isr,      // TIMER 2 OVF
+    NULL,         // TIMER 2 CAP
+    NULL,         // TIMER 3 OVF
+    NULL,         // TIMER 3 CAP
+    NULL,         // RESERVED
+    NULL,         // RESERVED
+    NULL,         // I2C
+    NULL,         // UART TX
+    NULL,         // UART RX
+    NULL,         // ADC
+    led1642_isr,  // TIMER 4 OVF
+    NULL,         // EEPROM ECC
+    NULL,         // Reserved
+    NULL,         // Reserved
+    NULL,         // Reserved
+    NULL,         // Reserved
+    NULL,         // Reserved
 };


### PR DESCRIPTION
Initially thought to be impossible, clang-format has been enabled on this repository. It seems like the macro games to hide Cosmic compiler keywords worked.